### PR TITLE
Fix: Remove link to non-existent index.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,6 @@
   }
 }
 </script>
-<link rel="stylesheet" href="/index.css">
 </head>
 <body class="bg-gray-100">
   <div id="root"></div>


### PR DESCRIPTION
Removed the <link> tag from index.html that referenced index.css, which was causing a 404 error as the file does not exist in the repository. Tailwind CSS is used via CDN and no other global CSS file is required.