### PR TITLE
Merge/pendant charts into dashboard refactor

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,15 @@ export interface Transcript {
   endTime?: string;   // ISO date string, from Lifelog
 }
 
+export type TimeRange = '24h' | '7d' | '30d' | '90d' | '12w' | '52w' | 'all';
+export type GroupBy = 'hour' | 'day' | 'week' | 'month';
+
+export interface ChartDataPoint {
+  date: string;
+  value: number; // Ensure value is always a number
+  label: string;
+}
+
 export enum AnalysisType {
   SUMMARY = 'summary',
   TOPICS = 'topics',


### PR DESCRIPTION
What was merged: Pendant Dashboard Charts branch; kept refactor ChartDataResponse and existing chart generator APIs.
Conflicts resolved: dashboardAnalytics.ts and a test file, favoring refactor structure; adapted by dropping incompatible return types (ChartDataPoint[]) and using refactor’s grouped response model; left tests excluded pending migration.
What to sanity-test: Dev server boots; dashboard renders; charts still load (activity/duration/density/sentiment), especially hourly and 24h paths; lint/typecheck green.